### PR TITLE
Remove @return null from constructor

### DIFF
--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -133,7 +133,6 @@ class <%= classname %> {
 	 * Sets up our plugin
 	 *
 	 * @since  <%= version %>
-	 * @return  null
 	 */
 	protected function __construct() {
 		$this->basename = plugin_basename( __FILE__ );


### PR DESCRIPTION
Constructors only ever return a class object, and IDEs complain when the docblock says they return something else.