### PR TITLE
include_file should be able to used generically

### DIFF
--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -57,7 +57,7 @@ function <%= prefix %>_autoload_classes( $class_name ) {
 		substr( $class_name, strlen( '<%= classprefix %>' ) )
 	) );
 
-	<%= classname %>::include_file( $filename );
+	<%= classname %>::include_file( 'includes/class-' . $filename );
 }
 spl_autoload_register( '<%= prefix %>_autoload_classes' );
 <% } else if ( autoloader == 'Composer' ) { %>
@@ -281,7 +281,7 @@ final class <%= classname %> {
 	 * @return bool   Result of include call.
 	 */
 	public static function include_file( $filename ) {
-		$file = self::dir( 'includes/class-'. $filename .'.php' );
+		$file = self::dir( $filename .'.php' );
 		if ( file_exists( $file ) ) {
 			return include_once( $file );
 		}


### PR DESCRIPTION
`include_file` should not assume that it will be used to include a class, nor should it assume it will be including a file in `/includes` as it could potentially be used to load files other directories (like `/views`, etc). Instead, append the `'includes/class-'` prefix in the autoloader, where it makes the most sense to assume a class in `/includes`.