### PR TITLE
fixed function name generation to use proper prefixing

### DIFF
--- a/widget/index.js
+++ b/widget/index.js
@@ -31,14 +31,14 @@ module.exports = base.extend({
       this.version      = this.pkg.version;
       if ( this.name ) {
         this.name       = this._.titleize( this.name.split('-').join(' ') );
-        this.nameslug = this._.slugify( this.name );
+        this.nameslug   = this._.slugify( this.name );
       }
-      this.pluginname   = this.rc.name;
-      this.widgetname   = this.pluginname + ' ' + this._.capitalize( this.name );
-      this.classname    = this.rc.classprefix + this._wpClassify( this.name );
-      this.slug         = this.rc.slug;
-      this.widgetslug   = this.slug + '-' + this._.slugify( this.name );
-      this.widgetprefix = this._.underscored( this.slug + ' ' + this.name );
+      this.pluginname     = this.rc.name;
+      this.widgetname     = this.pluginname + ' ' + this._.capitalize( this.name );
+      this.classname      = this.rc.classprefix + this._wpClassify( this.name );
+      this.slug           = this.rc.slug;
+      this.widgetslug     = this.slug + '-' + this._.slugify( this.name );
+      this.widgetregister = this._.underscored( this.slug + ' register ' + this.name );
     }
   },
 

--- a/widget/templates/widget.php
+++ b/widget/templates/widget.php
@@ -216,7 +216,7 @@ class <%= classname %> extends WP_Widget {
  * @since  NEXT
  * @return void
  */
-function register_<%= widgetprefix %>() {
+function <%= widgetregister %>() {
 	register_widget( '<%= classname %>' );
 }
-add_action( 'widgets_init', 'register_<%= widgetprefix %>' );
+add_action( 'widgets_init', '<%= widgetregister %>' );


### PR DESCRIPTION
This is a fix for https://github.com/WebDevStudios/generator-plugin-wp/issues/69
Widget Register function was not using proper WDS prefixing of wds_client_register_thing(). 