### PR TITLE
changed init priority to 0 to run prior to widgets_init

### DIFF
--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -157,8 +157,11 @@ final class <%= classname %> {
 	 * @return void
 	 */
 	public function hooks() {
-		// Priority needs to be < 10 for CPT and < 5 for taxonomy.
-		add_action( 'init', array( $this, 'init' ), 1 );
+		// Priority needs to be:
+		// < 10 for CPT_Core,
+		// < 5 for Taxonomy_Core,
+		// 0 Widgets because widgets_init runs at init priority 1.
+		add_action( 'init', array( $this, 'init' ), 0 );
 	}
 
 	/**


### PR DESCRIPTION
This is a fix for https://github.com/WebDevStudios/generator-plugin-wp/issues/68

Another option would be to do_action( 'widgets_init' ); sometime after the add_action( 'widgets_init', 'foo' );
