### PR TITLE
Feature/cmb2 taxonomy

### DIFF
--- a/taxonomy/index.js
+++ b/taxonomy/index.js
@@ -7,6 +7,8 @@ module.exports = base.extend({
   constructor: function () {
     base.apply(this, arguments);
 
+    this.option('nocmb2');
+
     this.argument('name', {
       required: false,
       type    : String,
@@ -137,6 +139,10 @@ module.exports = base.extend({
 
     if ( this.composer ) {
       this.spawnCommand('composer', ['require', 'webdevstudios/taxonomy_core']);
+
+      if ( !this.options.nocmb2 ) {
+        this.spawnCommand('composer', ['require', 'webdevstudios/cmb2']);
+      }
     } else {
       this.mkdir('vendor');
       if ( !this.fs.exists('vendor/taxonomy-core/Taxonomy_Core.php') ) {
@@ -145,6 +151,14 @@ module.exports = base.extend({
           repo: 'Taxonomy_Core',
           ref : 'master'
         }, this.destinationPath('vendor/taxonomy-core') );
+      }
+
+      if ( !this.fs.exists('vendor/cmb2/init.php') && !this.options.nocmb2 ) {
+        ghdownload({
+          user: 'WebDevStudios',
+          repo: 'CMB2',
+          ref : 'master'
+        }, this.destinationPath('vendor/cmb2') );
       }
     }
   }

--- a/taxonomy/templates/taxonomy.php
+++ b/taxonomy/templates/taxonomy.php
@@ -8,6 +8,9 @@
 
 <% if ( ! composer ) {
 	%>require_once dirname(__FILE__) . '/../vendor/taxonomy-core/Taxonomy_Core.php';<%
+	if ( ! options.nocmb2 ) { %>
+<%		%>require_once dirname(__FILE__) . '/../vendor/cmb2/init.php';<%
+	}
 } %>
 
 /**


### PR DESCRIPTION
Two commits:
The first 217d977 modified the taxonomy.php template to require CMB2.
Second commit 4c1f9f3 added logic to load CMB2 into vendor dir.  Without this logic the taxonomy template would work fine as long as it was generated after a CPT had already loaded CMB2.
