### PR TITLE
Feature/replace next

### DIFF
--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -43,7 +43,7 @@
 /**
  * Autoloads files with classes when needed
  *
- * @since  NEXT
+ * @since  <%= version %>
  * @param  string $class_name Name of the class being requested.
  * @return void
  */
@@ -70,7 +70,7 @@ require 'vendor/autoload_52.php';
 /**
  * Main initiation class
  *
- * @since  NEXT
+ * @since  <%= version %>
  */
 final class <%= classname %> {
 
@@ -78,7 +78,7 @@ final class <%= classname %> {
 	 * Current version
 	 *
 	 * @var  string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	const VERSION = '<%= version %>';
 
@@ -86,7 +86,7 @@ final class <%= classname %> {
 	 * URL of plugin directory
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $url = '';
 
@@ -94,7 +94,7 @@ final class <%= classname %> {
 	 * Path of plugin directory
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $path = '';
 
@@ -102,7 +102,7 @@ final class <%= classname %> {
 	 * Plugin basename
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $basename = '';
 
@@ -110,7 +110,7 @@ final class <%= classname %> {
 	 * Detailed activation error messages
 	 *
 	 * @var array
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $activation_errors = array();
 
@@ -118,14 +118,14 @@ final class <%= classname %> {
 	 * Singleton instance of plugin
 	 *
 	 * @var <%= classname %>
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected static $single_instance = null;
 
 	/**
 	 * Creates or returns an instance of this class.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return <%= classname %> A single instance of this class.
 	 */
 	public static function get_instance() {
@@ -139,7 +139,7 @@ final class <%= classname %> {
 	/**
 	 * Sets up our plugin
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected function __construct() {
 		$this->basename = plugin_basename( __FILE__ );
@@ -150,7 +150,7 @@ final class <%= classname %> {
 	/**
 	 * Attach other plugin classes to the base plugin class.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function plugin_classes() {
@@ -161,7 +161,7 @@ final class <%= classname %> {
 	/**
 	 * Add hooks and filters
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function hooks() {
@@ -175,7 +175,7 @@ final class <%= classname %> {
 	/**
 	 * Activate the plugin
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function _activate() {
@@ -187,7 +187,7 @@ final class <%= classname %> {
 	 * Deactivate the plugin
 	 * Uninstall routines should be in uninstall.php
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function _deactivate() {}
@@ -195,7 +195,7 @@ final class <%= classname %> {
 	/**
 	 * Init hooks
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function init() {
@@ -215,7 +215,7 @@ final class <%= classname %> {
 	 * Check if the plugin meets requirements and
 	 * disable it if they are not present.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return boolean result of meets_requirements
 	 */
 	public function check_requirements() {
@@ -236,7 +236,7 @@ final class <%= classname %> {
 	/**
 	 * Deactivates this plugin, hook this function on admin_init.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function deactivate_me() {
@@ -250,7 +250,7 @@ final class <%= classname %> {
 	/**
 	 * Check that all plugin requirements are met
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return boolean True if requirements are met.
 	 */
 	public function meets_requirements() {
@@ -264,7 +264,7 @@ final class <%= classname %> {
 	/**
 	 * Adds a notice to the dashboard if the plugin requirements are not met
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function requirements_not_met_notice() {
@@ -294,7 +294,7 @@ final class <%= classname %> {
 	/**
 	 * Magic getter for our object.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param string $field Field to get.
 	 * @throws Exception Throws an exception if the field is invalid.
 	 * @return mixed
@@ -315,7 +315,7 @@ final class <%= classname %> {
 	/**
 	 * Include a file from the includes directory
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  string $filename Name of the file to be included.
 	 * @return bool   Result of include call.
 	 */
@@ -330,7 +330,7 @@ final class <%= classname %> {
 	/**
 	 * This plugin's directory
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  string $path (optional) appended path.
 	 * @return string       Directory and path
 	 */
@@ -343,7 +343,7 @@ final class <%= classname %> {
 	/**
 	 * This plugin's url
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  string $path (optional) appended path.
 	 * @return string       URL and path
 	 */
@@ -358,7 +358,7 @@ final class <%= classname %> {
  * Grab the <%= classname %> object and return it.
  * Wrapper for <%= classname %>::get_instance()
  *
- * @since  NEXT
+ * @since  <%= version %>
  * @return <%= classname %>  Singleton instance of plugin class.
  */
 function <%= prefix %>() {

--- a/cli/templates/cli.php
+++ b/cli/templates/cli.php
@@ -9,14 +9,14 @@
 /**
  * <%= cliname %>.
  *
- * @since NEXT
+ * @since <%= version %>
  */
 class <%= classname %> {
 	/**
 	 * Parent plugin class
 	 *
 	 * @var   <%= mainclassname %>
-	 * @since NEXT
+	 * @since <%= version %>
 	 */
 	protected
 	$plugin = null;
@@ -62,7 +62,7 @@ class <%= classname %> {
 	/**
 	 * Create a method stub for our first CLI command.
 	 *
-	 * @since NEXT
+	 * @since <%= version %>
 	 * @return void
 	 */
 	public

--- a/cli/templates/cli.php
+++ b/cli/templates/cli.php
@@ -2,7 +2,7 @@
 /**
  * <%= cliname %>
  *
- * @since   NEXT
+ * @since   <%= version %>
  * @package <%= pluginname %>
  */
 
@@ -24,7 +24,7 @@ class <%= classname %> {
 	/**
 	 * Constructor
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 *
 	 * @param  <%= mainclassname %> $plugin Main plugin object.
 	 *
@@ -51,7 +51,7 @@ class <%= classname %> {
 	/**
 	 * Initiate our hooks
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public

--- a/cpt/index.js
+++ b/cpt/index.js
@@ -31,7 +31,7 @@ module.exports = base.extend({
     },
 
     settingValues: function() {
-      this.version    = this.pkg.version;
+      this.version = this.rc.version;
       if ( this.name ) {
         this.name     = this._.titleize( this.name.split('-').join(' ') );
         this.nameslug     = this._.slugify( this.name );
@@ -114,6 +114,7 @@ module.exports = base.extend({
   },
 
   writing: function () {
+
     this.fs.copyTpl(
       this.templatePath('cpt.php'),
       this.destinationPath('includes/class-' + this._.slugify( this.name ) + '.php'),
@@ -128,7 +129,7 @@ module.exports = base.extend({
       );
     }
 
-    this._addIncludeClass( this._.slugify( this.name ), this.classname );
+    this._addIncludeClass( this._.slugify( this.name ), this.classname, this.version );
   },
 
   install: function () {

--- a/cpt/templates/cpt.php
+++ b/cpt/templates/cpt.php
@@ -2,7 +2,7 @@
 /**
  * <%= cptname %>
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
@@ -17,7 +17,7 @@
  * <%= cptname %> post type class.
  *
  * @see https://github.com/WebDevStudios/CPT_Core
- * @since NEXT
+ * @since <%= version %>
  */
 class <%= classname %> extends CPT_Core {
 	/**

--- a/cpt/templates/cpt.php
+++ b/cpt/templates/cpt.php
@@ -24,7 +24,7 @@ class <%= classname %> extends CPT_Core {
 	 * Parent plugin class
 	 *
 	 * @var <%= mainclassname %>
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $plugin = null;
 
@@ -32,7 +32,7 @@ class <%= classname %> extends CPT_Core {
 	 * Constructor
 	 * Register Custom Post Types. See documentation in CPT_Core, and in wp-includes/post.php
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  <%= mainclassname %> $plugin Main plugin object.
 	 * @return void
 	 */
@@ -51,7 +51,7 @@ class <%= classname %> extends CPT_Core {
 	/**
 	 * Initiate our hooks
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function hooks() {<% if ( ! options.nocmb2 ) { %>
@@ -61,7 +61,7 @@ class <%= classname %> extends CPT_Core {
 	/**
 	 * Add custom fields to the CPT
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function fields() {
@@ -77,7 +77,7 @@ class <%= classname %> extends CPT_Core {
 	/**
 	 * Registers admin columns to display. Hooked in via CPT_Core.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  array $columns Array of registered column names/labels.
 	 * @return array          Modified array
 	 */
@@ -89,7 +89,7 @@ class <%= classname %> extends CPT_Core {
 	/**
 	 * Handles admin column display. Hooked in via CPT_Core.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param array $column  Column currently being rendered.
 	 * @param int   $post_id ID of post to display column for.
 	 */

--- a/endpoint/index.js
+++ b/endpoint/index.js
@@ -119,6 +119,6 @@ module.exports = base.extend({
       );
     }
 
-    this._addIncludeClass( this._.slugify( this.name ), this.classname );
+    this._addIncludeClass( this._.slugify( this.name ), this.classname, this.version );
   }
 });

--- a/endpoint/templates/endpoint.php
+++ b/endpoint/templates/endpoint.php
@@ -2,7 +2,7 @@
 /**
  * <%= includename %>
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
@@ -12,7 +12,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * Parent plugin class
 		 *
 		 * @var   <%= mainclassname %>
-		 * @since NEXT
+		 * @since <%= version %>
 		 */
 		protected $plugin = null;
 

--- a/endpoint/templates/endpoint.php
+++ b/endpoint/templates/endpoint.php
@@ -19,7 +19,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		/**
 		 * Constructor
 		 *
-		 * @since  NEXT
+		 * @since  <%= version %>
 		 * @param  <%= mainclassname %> $plugin Main plugin object.
 		 * @return void
 		 */
@@ -35,7 +35,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		/**
 	     * Register the routes for the objects of the controller.
 	     *
-	     * @since  NEXT
+	     * @since  <%= version %>
 		 * @return void
 	     */
 		public function register_routes() {

--- a/include/index.js
+++ b/include/index.js
@@ -117,6 +117,6 @@ module.exports = base.extend({
       );
     }
 
-    this._addIncludeClass( this._.slugify( this.name ), this.classname );
+    this._addIncludeClass( this._.slugify( this.name ), this.classname, this.version );
   }
 });

--- a/include/templates/include.php
+++ b/include/templates/include.php
@@ -2,21 +2,21 @@
 /**
  * <%= includename %>
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
 /**
  * <%= includename %>.
  *
- * @since NEXT
+ * @since <%= version %>
  */
 class <%= classname %> {
 	/**
 	 * Parent plugin class
 	 *
 	 * @var   <%= mainclassname %>
-	 * @since NEXT
+	 * @since <%= version %>
 	 */
 	protected $plugin = null;
 

--- a/include/templates/include.php
+++ b/include/templates/include.php
@@ -23,7 +23,7 @@ class <%= classname %> {
 	/**
 	 * Constructor
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  <%= mainclassname %> $plugin Main plugin object.
 	 * @return void
 	 */
@@ -35,7 +35,7 @@ class <%= classname %> {
 	/**
 	 * Initiate our hooks
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function hooks() {

--- a/options/index.js
+++ b/options/index.js
@@ -128,7 +128,7 @@ module.exports = base.extend({
       );
     }
 
-    this._addIncludeClass( this._.slugify( this.name ), this.classname );
+    this._addIncludeClass( this._.slugify( this.name ), this.classname, this.version );
   },
 
   install: function () {

--- a/options/templates/options.php
+++ b/options/templates/options.php
@@ -2,7 +2,7 @@
 /**
  * <%= optionsname %>
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
@@ -13,7 +13,7 @@
 /**
  * <%= optionsname %> class.
  *
- * @since NEXT
+ * @since <%= version %>
  */
 class <%= classname %> {
 	/**

--- a/options/templates/options.php
+++ b/options/templates/options.php
@@ -20,7 +20,7 @@ class <%= classname %> {
 	 * Parent plugin class
 	 *
 	 * @var    <%= mainclassname %>
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $plugin = null;
 
@@ -28,7 +28,7 @@ class <%= classname %> {
 	 * Option key, and option page slug
 	 *
 	 * @var    string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $key = '<%= optionsprefix %>';
 
@@ -36,7 +36,7 @@ class <%= classname %> {
 	 * Options page metabox id
 	 *
 	 * @var    string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $metabox_id = '<%= optionsprefix %>_metabox';
 
@@ -44,7 +44,7 @@ class <%= classname %> {
 	 * Options Page title
 	 *
 	 * @var    string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $title = '';
 
@@ -57,7 +57,7 @@ class <%= classname %> {
 	/**
 	 * Constructor
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  <%= mainclassname %> $plugin Main plugin object.
 	 * @return void
 	 */
@@ -71,7 +71,7 @@ class <%= classname %> {
 	/**
 	 * Initiate our hooks
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function hooks() {
@@ -83,7 +83,7 @@ class <%= classname %> {
 	/**
 	 * Register our setting to WP
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function admin_init() {
@@ -93,7 +93,7 @@ class <%= classname %> {
 	/**
 	 * Add menu options page
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function add_options_page() {
@@ -112,7 +112,7 @@ class <%= classname %> {
 	/**
 	 * Admin page markup. Mostly handled by CMB2
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function admin_page_display() {
@@ -127,7 +127,7 @@ class <%= classname %> {
 	/**
 	 * Add custom fields to the options page.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function add_options_page_metabox() {

--- a/pagebuilder/templates/class-pagebuilder.php
+++ b/pagebuilder/templates/class-pagebuilder.php
@@ -21,7 +21,7 @@ class <%= classname %> {
 	/**
 	 * Constructor
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  <%= mainclassname %> $plugin Main plugin object.
 	 * @return void
 	 */
@@ -33,7 +33,7 @@ class <%= classname %> {
 	/**
 	 * Initiate our hooks
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function hooks() {
@@ -43,7 +43,7 @@ class <%= classname %> {
 	/**
 	 * Registers our parts directory in the Page Builder template stack.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function load_pagebuilder_parts() {
@@ -54,7 +54,7 @@ class <%= classname %> {
 	 * Register our plugin's template parts directory.
 	 * This function needs to be in the global scope to work properly.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return string Absolute path to template parts directory.
 	 */
 	public function get_template_part_dir() {

--- a/pagebuilder/templates/class-pagebuilder.php
+++ b/pagebuilder/templates/class-pagebuilder.php
@@ -2,7 +2,7 @@
 /**
  * <%= pluginname %> Page Builder
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
@@ -14,7 +14,7 @@ class <%= classname %> {
 	 * Parent plugin class
 	 *
 	 * @var   <%= mainclassname %>
-	 * @since NEXT
+	 * @since <%= version %>
 	 */
 	protected $plugin = null;
 

--- a/plugin-wp-base.js
+++ b/plugin-wp-base.js
@@ -57,7 +57,7 @@ module.exports = yeoman.generators.Base.extend({
 		this.fs.write( this.destinationPath( this.rc.slug + '.php' ), mainPluginFile );
 	},
 
-	_addPluginProperty: function( file, slug, className ) {
+	_addPluginProperty: function( file, slug, className, version ) {
 
 		var toAdd = '\t/**';
 		toAdd += '\n\t * Instance of ' + className;
@@ -92,10 +92,11 @@ module.exports = yeoman.generators.Base.extend({
 			return;
 		}
 
-		slug = this._.underscored( slug );
+		slug    = this._.underscored( slug );
+		version = this.version;
 		var mainPluginFile = this.fs.read( this.destinationPath( this.rc.slug + '.php' ) );
 
-		mainPluginFile = this._addPluginProperty( mainPluginFile, slug, className );
+		mainPluginFile = this._addPluginProperty( mainPluginFile, slug, className, version );
 		mainPluginFile = this._addPluginClass( mainPluginFile, slug, className );
 		mainPluginFile = this._addPropertyMagicGetter( mainPluginFile, slug );
 

--- a/plugin-wp-base.js
+++ b/plugin-wp-base.js
@@ -62,7 +62,7 @@ module.exports = yeoman.generators.Base.extend({
 		var toAdd = '\t/**';
 		toAdd += '\n\t * Instance of ' + className;
 		toAdd += '\n\t *';
-		toAdd += '\n\t * @since <%= version %>';
+		toAdd += '\n\t * @since' + version;
 		toAdd += '\n\t * @var ' + className;
 		toAdd += '\n\t */';
 		toAdd += '\n\tprotected $' + slug + ';';

--- a/plugin-wp-base.js
+++ b/plugin-wp-base.js
@@ -87,13 +87,13 @@ module.exports = yeoman.generators.Base.extend({
 		return file.replace( endComment, newInclude );
 	},
 
-	_addIncludeClass: function( slug, className ) {
+	_addIncludeClass: function( slug, className, version ) {
+
 		if ( ! this.rc.slug ) {
 			return;
 		}
 
 		slug    = this._.underscored( slug );
-		version = this.rc.version;
 		var mainPluginFile = this.fs.read( this.destinationPath( this.rc.slug + '.php' ) );
 
 		mainPluginFile = this._addPluginProperty( mainPluginFile, slug, className, version );
@@ -102,4 +102,5 @@ module.exports = yeoman.generators.Base.extend({
 
 		this.fs.write( this.destinationPath( this.rc.slug + '.php' ), mainPluginFile );
 	}
+
 });

--- a/plugin-wp-base.js
+++ b/plugin-wp-base.js
@@ -93,7 +93,7 @@ module.exports = yeoman.generators.Base.extend({
 		}
 
 		slug    = this._.underscored( slug );
-		version = this.version;
+		version = this.rc.version;
 		var mainPluginFile = this.fs.read( this.destinationPath( this.rc.slug + '.php' ) );
 
 		mainPluginFile = this._addPluginProperty( mainPluginFile, slug, className, version );

--- a/plugin-wp-base.js
+++ b/plugin-wp-base.js
@@ -62,7 +62,7 @@ module.exports = yeoman.generators.Base.extend({
 		var toAdd = '\t/**';
 		toAdd += '\n\t * Instance of ' + className;
 		toAdd += '\n\t *';
-		toAdd += '\n\t * @since NEXT';
+		toAdd += '\n\t * @since <%= version %>';
 		toAdd += '\n\t * @var ' + className;
 		toAdd += '\n\t */';
 		toAdd += '\n\tprotected $' + slug + ';';

--- a/taxonomy/index.js
+++ b/taxonomy/index.js
@@ -129,7 +129,7 @@ module.exports = base.extend({
       );
     }
 
-    this._addIncludeClass( this._.slugify( this.name ), this.classname );
+    this._addIncludeClass( this._.slugify( this.name ), this.classname, this.version );
   },
 
   install: function () {

--- a/taxonomy/templates/taxonomy.php
+++ b/taxonomy/templates/taxonomy.php
@@ -24,7 +24,7 @@ class <%= classname %> extends Taxonomy_Core {
 	 * Parent plugin class
 	 *
 	 * @var <%= mainclassname %>
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $plugin = null;
 

--- a/taxonomy/templates/taxonomy.php
+++ b/taxonomy/templates/taxonomy.php
@@ -2,7 +2,7 @@
 /**
  * <%= taxonomyname %>
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
@@ -17,7 +17,7 @@
  * <%= taxonomyname %> class.
  *
  * @see https://github.com/WebDevStudios/Taxonomy_Core
- * @since NEXT
+ * @since <%= version %>
  */
 class <%= classname %> extends Taxonomy_Core {
 	/**
@@ -32,7 +32,7 @@ class <%= classname %> extends Taxonomy_Core {
 	 * Constructor
 	 * Register Taxonomy. See documentation in Taxonomy_Core, and in wp-includes/taxonomy.php
 	 *
-	 * @since NEXT
+	 * @since <%= version %>
 	 * @param  <%= mainclassname %> $plugin Main plugin object.
 	 * @return void
 	 */
@@ -54,7 +54,7 @@ class <%= classname %> extends Taxonomy_Core {
 	/**
 	 * Initiate our hooks
 	 *
-	 * @since NEXT
+	 * @since <%= version %>
 	 * @return void
 	 */
 	public function hooks() {

--- a/widget/templates/widget.php
+++ b/widget/templates/widget.php
@@ -19,7 +19,7 @@ class <%= classname %> extends WP_Widget {
 	 * Will also serve as the widget class.
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $widget_slug = '<%= widgetslug %>';
 
@@ -29,7 +29,7 @@ class <%= classname %> extends WP_Widget {
 	 * Set in __construct since __() shouldn't take a variable.
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $widget_name = '';
 
@@ -39,7 +39,7 @@ class <%= classname %> extends WP_Widget {
 	 * Set in __construct since __() shouldn't take a variable.
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected $default_widget_title = '';
 
@@ -48,7 +48,7 @@ class <%= classname %> extends WP_Widget {
 	 * Shortcode name for this widget
 	 *
 	 * @var string
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 */
 	protected static $shortcode = '<%= widgetslug %>';
 
@@ -56,7 +56,7 @@ class <%= classname %> extends WP_Widget {
 	/**
 	 * Construct widget class.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function __construct() {
@@ -86,7 +86,7 @@ class <%= classname %> extends WP_Widget {
 	 * Note: Could also delete any transients
 	 * delete_transient( 'some-transient-generated-by-this-widget' );
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @return void
 	 */
 	public function flush_widget_cache() {
@@ -97,7 +97,7 @@ class <%= classname %> extends WP_Widget {
 	/**
 	 * Front-end display of widget.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  array $args     The widget arguments set up when a sidebar is registered.
 	 * @param  array $instance The widget settings as set by user.
 	 * @return void
@@ -117,7 +117,7 @@ class <%= classname %> extends WP_Widget {
 	/**
 	 * Return the widget/shortcode output
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  array $atts Array of widget/shortcode attributes/args.
 	 * @return string       Widget output
 	 */
@@ -156,7 +156,7 @@ class <%= classname %> extends WP_Widget {
 	/**
 	 * Update form values as they are saved.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  array $new_instance New settings for this instance as input by the user.
 	 * @param  array $old_instance Old settings for this instance.
 	 * @return array               Settings to save or bool false to cancel saving.
@@ -186,7 +186,7 @@ class <%= classname %> extends WP_Widget {
 	/**
 	 * Back-end widget form with defaults.
 	 *
-	 * @since  NEXT
+	 * @since  <%= version %>
 	 * @param  array $instance Current settings.
 	 * @return void
 	 */
@@ -213,7 +213,7 @@ class <%= classname %> extends WP_Widget {
 /**
  * Register this widget with WordPress. Can also move this function to the parent plugin.
  *
- * @since  NEXT
+ * @since  <%= version %>
  * @return void
  */
 function <%= widgetregister %>() {

--- a/widget/templates/widget.php
+++ b/widget/templates/widget.php
@@ -2,14 +2,14 @@
 /**
  * <%= widgetname %>
  *
- * @since NEXT
+ * @since <%= version %>
  * @package <%= pluginname %>
  */
 
 /**
  * <%= widgetname %> class.
  *
- * @since NEXT
+ * @since <%= version %>
  */
 class <%= classname %> extends WP_Widget {
 


### PR DESCRIPTION
This is in response to:
Uses the version number originally entered by default.  

This means that if the version is bumped in the .yo-rc.json file, the future generated files will use the new version.  

https://github.com/WebDevStudios/generator-plugin-wp/issues/96