### PR TITLE
Make PHP 5.2 support optional (off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ the main folder of your plugin.
 If you don't want tests included in your plugin when it is generated run the
 main generator with the `--notests` option.
 
+## PHP 5.2
+
+By default PHP 5.2 is not supported in the generated plugin. To generate a plugin
+with PHP 5.2 support, run the main generator with the `--php52` option.
+
 ### Adding Packages with Composer
 
 If you chose composer as the autoloader option during the plugin's initiation,

--- a/app/index.js
+++ b/app/index.js
@@ -12,6 +12,11 @@ module.exports = base.extend({
     base.apply(this, arguments);
 
     this.option('notests');
+    this.option('php52', {
+      type: Boolean,
+      required: false,
+      desc: 'Include PHP 5.2 support'
+    });
   },
 
   initializing: function () {
@@ -126,6 +131,7 @@ module.exports = base.extend({
       this.prefix      = this._.underscored( props.prefix );
       this.year        = new Date().getFullYear();
       this.autoloader  = props.autoloader;
+      this.php52       = this.options.php52;
 
       done();
     }.bind(this));

--- a/app/templates/composer.json
+++ b/app/templates/composer.json
@@ -14,20 +14,21 @@
 	"type": "wordpress-plugin",
 	"autoload": {
 		"classmap": ["<%= slug %>.php", "includes/"]
-	},
+	}<%if (php52) { %>,
 	"require": {
 		"php": ">=5.2",
 		"xrstf/composer-php52": "1.*"
 	},
 	"scripts": {
-        "post-install-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-update-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-autoload-dump": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ]
-    }
+    "post-install-cmd": [
+        "xrstf\\Composer52\\Generator::onPostInstallCmd"
+    ],
+    "post-update-cmd": [
+        "xrstf\\Composer52\\Generator::onPostInstallCmd"
+    ],
+    "post-autoload-dump": [
+        "xrstf\\Composer52\\Generator::onPostInstallCmd"
+    ]
+  }
+  <% } %>
 }

--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -60,9 +60,12 @@ function <%= prefix %>_autoload_classes( $class_name ) {
 	<%= classname %>::include_file( 'includes/class-' . $filename );
 }
 spl_autoload_register( '<%= prefix %>_autoload_classes' );
+<% } else if ( autoloader == 'Composer' && php52 ) { %>
+// User composer autoload with PHP 5.2 compatibility.
+require 'vendor/autoload_52.php';
 <% } else if ( autoloader == 'Composer' ) { %>
 // User composer autoload.
-require 'vendor/autoload_52.php';
+require 'vendor/autoload.php';
 <% } else { %>
 // Include additional php files here.
 // require 'includes/admin.php';


### PR DESCRIPTION
Adds a command line flag `--php52` which, if passed,
generates a `composer.json` and `[PLUGIN_NAME].php` which include
support for PHP 5.2. Otherwise, PHP 5.2 is not supported.

Closes #122