### PR TITLE
Update Dockunit

### DIFF
--- a/app/templates/Dockunit.json
+++ b/app/templates/Dockunit.json
@@ -10,7 +10,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "prettyName":"PHP 7.0 FPM WordPress 4.7",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -19,7 +19,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "prettyName":"PHP 7.0 FPM WordPress 4.6",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -28,7 +28,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "prettyName":"PHP 7.0 FPM WordPress 4.5",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -37,7 +37,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "prettyName":"PHP 7.0 FPM WordPress 4.4",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -64,7 +64,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "prettyName":"PHP 5.6 FPM WordPress 4.7",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -73,7 +73,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "prettyName":"PHP 5.6 FPM WordPress 4.6",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -82,7 +82,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "prettyName":"PHP 5.6 FPM WordPress 4.5",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
          "beforeScripts":[
             "service mysql start",
@@ -91,7 +91,7 @@
          "testCommand":"phpunit"
       },
       {
-         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "prettyName":"PHP 5.6 FPM WordPress 4.4",
          "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
          "beforeScripts":[
             "service mysql start",

--- a/app/templates/Dockunit.json
+++ b/app/templates/Dockunit.json
@@ -1,31 +1,157 @@
 {
-  "containers": [
-    {
-      "prettyName": "PHP 5.2 FPM WordPress 4.3",
-      "image": "dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.2-fpm",
-      "beforeScripts": [
-        "service mysql start",
-        "bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.3"
-      ],
-      "testCommand": "phpunit"
-    },
-    {
-      "prettyName": "PHP 5.6 FPM WordPress 4.2",
-      "image": "dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
-      "beforeScripts": [
-        "service mysql start",
-        "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost 4.2"
-      ],
-      "testCommand": "phpunit"
-    },
-    {
-      "prettyName": "PHP 7.0 FPM Latest WordPress",
-      "image": "dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-fpm",
-      "beforeScripts": [
-        "service mysql start",
-        "bash bin/install-wp-tests.sh wordpress_test3 root '' localhost"
-      ],
-      "testCommand": "phpunit"
-    }
-  ]
+   "containers":[
+      {
+         "prettyName":"PHP 7.0 FPM WordPress Latest",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test root '' localhost"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.7"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.6"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.5"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.4"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 7.0 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-7.0-rc-4-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.3"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.6 FPM WordPress Latest",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost 4.7"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost 4.6"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost 4.5"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost 4.4"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.6 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.6-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test2 root '' localhost 4.3"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.2 FPM WordPress 4.7",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.2-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test3 root '' localhost 4.7"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.2 FPM WordPress 4.6",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.2-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test3 root '' localhost 4.6"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.2 FPM WordPress 4.5",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.2-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test3 root '' localhost 4.5"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.2 FPM WordPress 4.4",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.2-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test3 root '' localhost 4.4"
+         ],
+         "testCommand":"phpunit"
+      },
+      {
+         "prettyName":"PHP 5.2 FPM WordPress 4.3",
+         "image":"dockunit/prebuilt-images:php-mysql-phpunit-wordpress-5.2-fpm",
+         "beforeScripts":[
+            "service mysql start",
+            "bash bin/install-wp-tests.sh wordpress_test3 root '' localhost 4.3"
+         ],
+         "testCommand":"phpunit"
+      }
+   ]
 }


### PR DESCRIPTION
Update Dockunit to run test on WP versions 4.3->4.7 and latest, on PHP 5.2, 5.6, and 7.0.