### PR TITLE
Add check for rest-api plugin before blindly including it.

### DIFF
--- a/app/templates/tests/bootstrap.php
+++ b/app/templates/tests/bootstrap.php
@@ -9,7 +9,7 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	// Include the REST API main plugin file if we're using it so we can run endpoint tests.
-	if ( class_exists( 'WP_REST_Controller' ) ) {
+	if ( class_exists( 'WP_REST_Controller' ) && file_exists( WP_PLUGIN_DIR . '/rest-api/plugin.php' ) ) {
 		require WP_PLUGIN_DIR . '/rest-api/plugin.php';
 	}
 	require dirname( dirname( __FILE__ ) ) . '/<%= slug %>.php';


### PR DESCRIPTION
Now that WP_REST_Controller doesn't always come from the plugin, we can't assume it will exist.