### PR TITLE
Document how to test.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Testing Your Changes
+
+To test `yo plugin-wp` using any changes you've made, while in the repo
+folder, run `npm link` and NPM will know to use `yo plugin-wp` using the code
+and templates from the repo.
+
+To get back to the official NPM `plugin-wp` command, do:
+
+```
+npm unlink && npm install -g generator-plugin-wp
+```


### PR DESCRIPTION
- Add CONTRIBUTING.md
- Add section on how to test changes

Note the `npm unlink` and `npm install` are BOTH required to restore
plugin-wp command back to non-repo.

Closes #128 when merged.