### PR TITLE
Abort activation hook tasks if requirements aren't met

### DIFF
--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -177,6 +177,10 @@ final class <%= classname %> {
 	 * @since  <%= version %>
 	 */
 	public function _activate() {
+		// Bail early if requirements aren't met.
+		if ( ! $this->check_requirements() ) {
+			return;
+		}
 
 		// Make sure any rewrite functionality has been loaded.
 		flush_rewrite_rules();

--- a/test/test-assets/subgenerator-test-plugin/subgenerator-test-plugin.php
+++ b/test/test-assets/subgenerator-test-plugin/subgenerator-test-plugin.php
@@ -168,6 +168,10 @@ final class Subgenerator_Test_Plugin {
 	 * @since  0.1.0
 	 */
 	public function _activate() {
+		// Bail early if requirements aren't met.
+		if ( ! $this->check_requirements() ) {
+			return;
+		}
 
 		// Make sure any rewrite functionality has been loaded.
 		flush_rewrite_rules();


### PR DESCRIPTION
This adds the code used in the `init` hook to the `_activate` function as well.

If the plugin requirements aren't met and the plugin is not activated, then activation hooks should not run.

A good example of this use case can be found [here](https://github.com/INN/client-hosting-manager/blob/master/client-hosting-manager.php), where important actions are happening on plugin activation that should not occur if the plugin requirements are not met.