### PR TITLE
Add menu icon and public array keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
 before_install:
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'generator-plugin-wp' ]; then cd .. && eval "mv $currentfolder generator-plugin-wp" && cd generator-plugin-wp; fi
+notifications:
+  slack:
+    secure: HSOxec12MVmrsccR3tqFgW2e4FcsO39OrOwxhDuCJBfHUEAJs99unlk/fjxe7bRRc7X85q+jyzKu/13dO4WGT51HnPnpDL/r5SNCIDGjSlpmfRfx7XAe1FLdZbY9gYHeGbGoL9Z3jvvq4UEyv6HHhy19X+NQDBmg8yp4OxECLtLKT+kFIyGCngOuu3GcXiLurKToeDBb3L0lE0mxcnslZRGSldFSH9RfnX5v96Wst+LvXF+HXiRJb+FOdL1aeGz4UiT4kzUFWWI03WNpF7HuQojP7getM9Wzhl3os6NR7TlDN5LR8SNIvBsG0zbTG37Qt0hoFDCQ5D9igYNN9rhlOfc3t+LmujAepZXx7xiuDRQoRe1nQBAeD0pY3NhdeCFNWFUqyWpcXrdAv5/8oLfuS6w4N2tCHDG46wfmkgIFCV06TjYTce1duWiJoypPveyjA4ePlbQcxzGXwStQrHspChMp2QI8VTbLD3RQ9DwlIo5QAID/f2U4cCPs6HQeo28w60oBZrCb6bjOJikBs33M1E2oc9teFbqeMKo7xFZ9kttsIBHGpFms1oRymw+idxkgFmoNOzBhCZV16Yp/8T9Xi4OfI/jJpwwWDFLsenJarMgoXScifpO9DkFMTiXDcLP4fVTti18HiQEq6aCStzQpPfejtgnS3Okp2UWxFpb0gHM=

--- a/cpt/templates/cpt.php
+++ b/cpt/templates/cpt.php
@@ -48,8 +48,8 @@ class <%= classname %> extends CPT_Core {
 		// First parameter should be an array with Singular, Plural, and Registered name.
 		parent::__construct(
 			array(
-				__( '<%= cptname %>', '<%= slug %>' ),
-				__( '<%= cptname %>s', '<%= slug %>' ),
+				esc_html__( '<%= cptname %>', '<%= slug %>' ),
+				esc_html__( '<%= cptname %>s', '<%= slug %>' ),
 				'<%= cptslug %>',
 			),
 			array(
@@ -87,7 +87,7 @@ class <%= classname %> extends CPT_Core {
 		// Define our metaboxes and fields.
 		$cmb = new_cmb2_box( array(
 			'id'            => $prefix . 'metabox',
-			'title'         => __( '<%= cptname %> Meta Box', '<%= slug %>' ),
+			'title'         => esc_html__( '<%= cptname %> Meta Box', '<%= slug %>' ),
 			'object_types'  => array( '<%= cptslug %>' ),
 		) );<% } %>
 	}

--- a/cpt/templates/cpt.php
+++ b/cpt/templates/cpt.php
@@ -59,6 +59,8 @@ class <%= classname %> extends CPT_Core {
 					'excerpt',
 					'thumbnail',
 				),
+				'menu_icon' => 'dashicons-admin-post', // https://developer.wordpress.org/resource/dashicons/
+				'public'    => true,
 			)
 		);
 	}


### PR DESCRIPTION
I feel like we always have to come back and add an icon. And sometimes we have to hide a CPT so the Yoast Metabox doesn't appear on non-public facing CPTs

Can we just include these two array keys out of the box? That way, we can do these tasks when the CPT is generated. 

Thanks!