### PR TITLE
Create USAGE file to add subgenerators to --help flag.

### DIFF
--- a/app/USAGE
+++ b/app/USAGE
@@ -1,0 +1,10 @@
+Subgenerators:
+	yo plugin-wp:include <include-name>
+	yo plugin-wp:cpt <cpt-name>
+	yo plugin-wp:cli <cli-command-name>
+	yo plugin-wp:taxonomy <taxonomy-name>
+	yo plugin-wp:options <options-name>
+	yo plugin-wp:widget <widget-name>
+	yo plugin-wp:endpoint <class-name>
+	yo plugin-wp:js
+	yo plugin-wp:css


### PR DESCRIPTION
Running `yo plugin-wp --help` now outputs the following:

```
Usage:
  yo plugin-wp:app [options] 

Options:
  -h,   --help        # Print the generator's options and usage
        --skip-cache  # Do not remember prompt answers           Default: false
        --do-install  # Automatically install dependecies
        --php52       # Include PHP 5.2 support

Subgenerators:
	yo plugin-wp:include <include-name>
	yo plugin-wp:cpt <cpt-name>
	yo plugin-wp:cli <cli-command-name>
	yo plugin-wp:taxonomy <taxonomy-name>
	yo plugin-wp:options <options-name>
	yo plugin-wp:widget <widget-name>
	yo plugin-wp:endpoint <class-name>
	yo plugin-wp:js
	yo plugin-wp:css
```


This closes #141 