### PR TITLE
Stores the plugin generator version

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -41,6 +41,11 @@ module.exports = base.extend({
 
     // Check and see if Composer is available.
     this.checkComposerStatus();
+
+    // Get the plugin gen version.
+    var pjson = require( '../package.json' );
+    this.plugingenversion = pjson.version;
+
   },
 
   prompting: function () {
@@ -327,6 +332,8 @@ module.exports = base.extend({
       this.config.set( 'year', this.year );
 
       this.config.set( 'currentVersionWP', this.currentVersionWP );
+
+      this.config.set( 'plugingenversion', this.plugingenversion );
 
       this.config.save();
     }


### PR DESCRIPTION
This is a super simple addition.
I expect in the future knowing what version of the generator was used will be valuable for determining how to handle the subgens.

This simply adds the plugin-gen version to the .yo.rc.json file.
I expect this will be significantly less contentious than my last big idea. :lol: