### PR TITLE
Fixes the property test added by default to the include tests.php file

### DIFF
--- a/include/index.js
+++ b/include/index.js
@@ -31,6 +31,7 @@ module.exports = base.extend({
       if ( this.name ) {
         this.name      = this._.titleize( this.name.split('-').join(' ') );
         this.nameslug  = this._.slugify( this.name );
+        this.property  = this._.underscored( this.nameslug );
       }
       this.pluginname  = this.rc.name;
       this.includename = this.pluginname + ' ' + this._.capitalize( this.name );

--- a/include/templates/tests.php
+++ b/include/templates/tests.php
@@ -22,7 +22,7 @@ class <%= classname %>_Test extends WP_UnitTestCase {
 	 * @since  <%= version %>
 	 */
 	function test_class_access() {
-		$this->assertInstanceOf( '<%= classname %>', <%= rc.prefix %>()-><%= nameslug %> );
+		$this->assertInstanceOf( '<%= classname %>', <%= rc.prefix %>()-><%= property %> );
 	}
 
 	/**


### PR DESCRIPTION
This is a fix for the scaffolded test files.

Previously testing was looking for the existence of properties.  However, the property names were problematic if the class they belonged to were multiple words as the title function was replacing spaces with dashes.

This update fixes the basic unit tests that pretty much just prove unit can be tested.