### PR TITLE
REST API tests enhancements

### DIFF
--- a/endpoint/templates/tests.php
+++ b/endpoint/templates/tests.php
@@ -7,6 +7,17 @@
  */
 class <%= classname %>_Test extends WP_UnitTestCase {
 
+	function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server;
+		do_action( 'rest_api_init' );
+
+		$this->subscriber = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->administrator = $this->factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
 	/**
 	 * Test if our class exists.
 	 *
@@ -33,4 +44,16 @@ class <%= classname %>_Test extends WP_UnitTestCase {
 	function test_sample() {
 		$this->assertTrue( true );
 	}
+
+	/**
+	* Turn off Rest server.
+	*
+	* @since  1.2.0
+	*/
+   public function tearDown() {
+	   parent::tearDown();
+
+	   global $wp_rest_server;
+	   $wp_rest_server = null;
+   }
 }

--- a/endpoint/templates/tests.php
+++ b/endpoint/templates/tests.php
@@ -42,6 +42,14 @@ class <%= classname %>_Test extends WP_UnitTestCase {
 	 * @since  <%= version %>
 	 */
 	function test_sample() {
+		/*
+		wp_set_current_user( $this->administrator );
+
+		$request = new WP_REST_Request( 'POST', '/endpoint' );
+		$request->set_param( 'key', 'value' );
+		$response = $this->server->dispatch( $request );
+		$this->assertResponseStatus( 200, $response );
+		*/
 		$this->assertTrue( true );
 	}
 

--- a/endpoint/templates/tests.php
+++ b/endpoint/templates/tests.php
@@ -46,9 +46,53 @@ class <%= classname %>_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test response status for API request.
+	 *
+	 * @since  <%= version %>
+	 */
+	protected function assertResponseStatus( $status, $response, $error_code = '', $debug = false ) {
+         if ( $debug ) {
+             error_log( '$response->get_data(): '. print_r( $response->get_data(), true ) );
+         }
+         $this->assertEquals( $status, $response->get_status() );
+
+         if ( $error_code ) {
+             $this->assertResponseErrorCode( $error_code, $response );
+         }
+     }
+
+	 /**
+ 	 * Test response error code for API request.
+ 	 *
+ 	 * @since  <%= version %>
+ 	 */
+     protected function assertResponseErrorCode( $error_code, $response ) {
+         $response_data = $response->get_data();
+         $this->assertEquals( $error_code, $response_data['code'] );
+     }
+
+	 /**
+ 	 * Test response data for API request.
+ 	 *
+ 	 * @since  <%= version %>
+ 	 */
+     protected function assertResponseData( $data, $response ) {
+         $response_data = $response->get_data();
+         $tested_data = array();
+         foreach( $data as $key => $value ) {
+             if ( isset( $response_data[ $key ] ) ) {
+                 $tested_data[ $key ] = $response_data[ $key ];
+             } else {
+                 $tested_data[ $key ] = null;
+             }
+         }
+         $this->assertEquals( $data, $tested_data );
+     }
+
+	/**
 	* Turn off Rest server.
 	*
-	* @since  1.2.0
+	* @since  <%= version %>
 	*/
    public function tearDown() {
 	   parent::tearDown();


### PR DESCRIPTION
This PR is a first-pass at #155

- I've integrated the server setup/teardown from https://pantheon.io/blog/test-coverage-your-wp-rest-api-project
- This includes some of the helper functions from the CMB2 endpoint tests (https://cmb2.io/api/source-class-Test_CMB2_Rest_Base.html#99-126)

I'm not sure how you'd want to have a more comprehensive basic test setup, so I added a basic example in a block comment for now. Ideally I'd like to get your feedback on the approach you'd want to take here.