### PR TITLE
Removes CMB2 as a default on CPT/Taxonomy

### DIFF
--- a/cpt/README.md
+++ b/cpt/README.md
@@ -4,8 +4,8 @@
 yo plugin-wp:cpt <cpt-name>
 ```
 
-Creates a skeleton custom post type using [CPT_Core](https://github.com/WebDevStudios/CPT_Core) and [CMB2](https://github.com/WebDevStudios/CMB2) for custom fields.
+Creates a skeleton custom post type using [CPT_Core](https://github.com/WebDevStudios/CPT_Core).
 
-You can optionally not include CMB2 by using the `--nocmb2` option when running the subgenerator.
+You can optionally include [CMB2](https://github.com/WebDevStudios/CMB2) by using the `--cmb2` option when running the subgenerator.
 
 Refer to [CPT_Core](https://github.com/WebDevStudios/CPT_Core) for more details on extending the CPT_Core class.

--- a/cpt/index.js
+++ b/cpt/index.js
@@ -6,7 +6,7 @@ module.exports = base.extend({
   constructor: function () {
     base.apply(this, arguments);
 
-    this.option('nocmb2');
+    this.option('cmb2');
 
     this.argument('name', {
       required: false,
@@ -140,7 +140,7 @@ module.exports = base.extend({
     if ( this.composer ) {
       this.spawnCommand('composer', ['require', 'webdevstudios/cpt-core']);
 
-      if ( !this.options.nocmb2 ) {
+      if ( this.options.cmb2 ) {
         this.spawnCommand('composer', ['require', 'webdevstudios/cmb2']);
       }
     } else {
@@ -153,7 +153,7 @@ module.exports = base.extend({
         }, this.destinationPath('vendor/cpt-core') );
       }
 
-      if ( !this.fs.exists('vendor/cmb2/init.php') && !this.options.nocmb2 ) {
+      if ( !this.fs.exists('vendor/cmb2/init.php') && this.options.cmb2 ) {
         ghdownload({
           user: 'WebDevStudios',
           repo: 'CMB2',

--- a/cpt/templates/cpt.php
+++ b/cpt/templates/cpt.php
@@ -8,7 +8,7 @@
 
 <% if ( ! composer ) {
 	%>require_once dirname( __FILE__ ) . '/../vendor/cpt-core/CPT_Core.php';<%
-	if ( ! options.nocmb2 ) { %>
+	if ( options.cmb2 ) { %>
 <%		%>require_once dirname( __FILE__ ) . '/../vendor/cmb2/init.php';<%
 	}
 } %>
@@ -70,7 +70,7 @@ class <%= classname %> extends CPT_Core {
 	 *
 	 * @since  <%= version %>
 	 */
-	public function hooks() {<% if ( ! options.nocmb2 ) { %>
+	public function hooks() {<% if ( options.cmb2 ) { %>
 		add_action( 'cmb2_init', array( $this, 'fields' ) );
 	}
 

--- a/options/templates/options.php
+++ b/options/templates/options.php
@@ -6,7 +6,7 @@
  * @package <%= mainclassname %>
  */
 
-<% if ( ! composer && ! options.nocmb2 ) {
+<% if ( ! composer && options.nocmb2 ) {
 	%>require_once dirname( __FILE__ ) . '/../vendor/cmb2/init.php';<%
 } %>
 

--- a/taxonomy/index.js
+++ b/taxonomy/index.js
@@ -6,7 +6,7 @@ module.exports = base.extend({
   constructor: function () {
     base.apply(this, arguments);
 
-    this.option('nocmb2');
+    this.option('cmb2');
 
     this.argument('name', {
       required: false,
@@ -139,7 +139,7 @@ module.exports = base.extend({
     if ( this.composer ) {
       this.spawnCommand('composer', ['require', 'webdevstudios/taxonomy_core']);
 
-      if ( !this.options.nocmb2 ) {
+      if ( this.options.cmb2 ) {
         this.spawnCommand('composer', ['require', 'webdevstudios/cmb2']);
       }
     } else {
@@ -152,7 +152,7 @@ module.exports = base.extend({
         }, this.destinationPath('vendor/taxonomy-core') );
       }
 
-      if ( !this.fs.exists('vendor/cmb2/init.php') && !this.options.nocmb2 ) {
+      if ( !this.fs.exists('vendor/cmb2/init.php') && this.options.cmb2 ) {
         ghdownload({
           user: 'WebDevStudios',
           repo: 'CMB2',

--- a/taxonomy/templates/taxonomy.php
+++ b/taxonomy/templates/taxonomy.php
@@ -8,7 +8,7 @@
 
 <% if ( ! composer ) {
 	%>require_once dirname( __FILE__ ) . '/../vendor/taxonomy-core/Taxonomy_Core.php';<%
-	if ( ! options.nocmb2 ) { %>
+	if ( options.cmb2 ) { %>
 <%		%>require_once dirname( __FILE__ ) . '/../vendor/cmb2/init.php';<%
 	}
 } %>


### PR DESCRIPTION
This branch defaults to NOT include CMB2 during sub-generation of CPT and Taxonomy.
By passing the flag `--cmb2` CMB2 is included.

This will close #160 when merged.