### PR TITLE
returns from function after parsing the first instance

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -360,6 +360,7 @@ module.exports = base.extend({
         for ( var i in data.offers ) {
           if ( 'upgrade' === data.offers[i].response ) {
             this.currentVersionWP = data.offers[i].current;
+            return;
           }
         }
       }


### PR DESCRIPTION
Returning seems to fix the issue where the var isn't set.

To test...the generated README.md should have: 
**Tested up to:**      4.8.1
around line 6.

Thanks!
Gary