### PR TITLE
grunt.js grunt release replace readme.txt should be after copy

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -191,7 +191,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'default', ['styles', 'scripts', 'php'] );
 
 	grunt.registerTask( 'version', [ 'default', 'replace:version_php', 'replace:version_readme' ] );
-	grunt.registerTask( 'release', [ 'clean:release', 'replace:readme_txt', 'copy', 'compress', 'wp_deploy' ] );
+	grunt.registerTask( 'release', [ 'clean:release', 'copy', 'replace:readme_txt', 'compress', 'wp_deploy' ] );
 
 	grunt.util.linefeed = '\n';
 };


### PR DESCRIPTION
grunt release
replace readme.txt is executed after clean command, there are no more readme.txt to replace.
move repace readme.txt to after copy command