### PR TITLE
Fixes the options generator issue #173

### DIFF
--- a/options/templates/options.php
+++ b/options/templates/options.php
@@ -6,7 +6,7 @@
  * @package <%= mainclassname %>
  */
 
-<% if ( ! composer && options.nocmb2 ) {
+<% if ( ! composer && ! options.nocmb2 ) {
 	%>require_once dirname( __FILE__ ) . '/../vendor/cmb2/init.php';<%
 } %>
 


### PR DESCRIPTION
It turns out the options generator was looking for the --nocmb2 flag, but was adding the CMB2 library in the opposite circumstance it should have been. (Added when the flag was used, and not added with no flag).