### PR TITLE
Issue/176 readme license fix

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -359,6 +359,9 @@ module.exports = base.extend({
   },
 
   getLatestWPVersion: function() {
+    // Save the generator (this) to a variable so that we can access it within the nested function below.
+    var generator = this;
+
     request.get({
       url: 'https://api.wordpress.org/core/version-check/1.7/',
       json: true,
@@ -369,7 +372,7 @@ module.exports = base.extend({
         // Loop through results to find only the "upgrade" version
         for ( var i in data.offers ) {
           if ( 'upgrade' === data.offers[i].response ) {
-            this.currentVersionWP = data.offers[i].current;
+            generator.currentVersionWP = data.offers[i].current;
             return;
           }
         }

--- a/app/index.js
+++ b/app/index.js
@@ -31,7 +31,7 @@ module.exports = base.extend({
     this.pkg = require('../package.json');
 
     // Set the initial value.
-    this.currentVersionWP = '4.8.1';
+    this.currentVersionWP = '5.0.7';
 
     // Get the latest WP version.
     this.getLatestWPVersion();

--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -1,12 +1,12 @@
 # <%= name %> #
-**Contributors:**      <%= author %>  
-**Donate link:**       <%= homepage %>  
-**Tags:**  
-**Requires at least:** 4.4  
-**Tested up to:**      <%= currentVersionWP %> 
-**Stable tag:**        <%= version %>  
-**License:**           <%= license %>  
-**License URI:**       <%= licenseuri %>  
+**Contributors:**      <%= author %>
+**Donate link:**       <%= homepage %>
+**Tags:**
+**Requires at least:** 5.0.7
+**Tested up to:**      <%= currentVersionWP %>
+**Stable tag:**        <%= version %>
+**License:**           <%= license %>
+**License URI:**       <%= licenseuri %>
 
 ## Description ##
 

--- a/app/templates/plugin.php
+++ b/app/templates/plugin.php
@@ -8,6 +8,7 @@
  * Author URI:  <%= authorurl %>
  * Donate link: <%= homepage %>
  * License:     <%= license %>
+ * License URI: <%= licenseuri %>
  * Text Domain: <%= slug %>
  * Domain Path: /languages
  *
@@ -18,7 +19,7 @@
  *
  * Built using generator-plugin-wp (https://github.com/WebDevStudios/generator-plugin-wp)
  */
-
+<% if ( license == 'GPLv2' ) { %>
 /**
  * Copyright (c) <%= year %> <%= author %> (email : <%= authoremail %>)
  *
@@ -35,8 +36,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- */
-
+ */<% } else { %>
+/**
+ * Copyright (c) <%= year %> <%= author %> (email : <%= authoremail %>)
+ */<% } %>
 <% if ( autoloader == 'Basic' ) { %>
 /**
  * Autoloads files with classes when needed.


### PR DESCRIPTION
This PR allows a custom license and license URI to be specified; the GPLv2 license is no longer assumed but it is still the default option. The GPLv2 license is only added to the readme.md file if it was selected.

Other `readme.md` fixes:
- The `getLatestWPVersion()` function has been fixed and now correctly sets the latest version of WP.
- The default minimum WP version has been bumped to  5.0.7.