### PR TITLE
Add npm-shrinkwrap.json to allow usage of node 12x

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "graceful-fs": {
+        "version": "4.2.2"
+     }
+  }
+}


### PR DESCRIPTION
Hi @gregrickaby,

This PR allows the Plugin Generator to run under Node 12x using the workaround discussed in this link: https://timonweb.com/posts/how-to-fix-referenceerror-primordials-is-not-defined-error/

I tested this using NVM and Node v12.12.0 and I was able to generate a plugin and no longer encountered the "ReferenceError: primordials is not defined" error.
